### PR TITLE
Updates the test name presented at json reduce use of helper files 

### DIFF
--- a/bin/run.ijs
+++ b/bin/run.ijs
@@ -81,7 +81,7 @@ main=: monad define
   (1!:55 :: '') tasksPath
   
   descriptions=. |: ,: (<'name') ,: descriptions                                       NB. descriptions and tasks has shape (# tests) 2 1 in order to simplify the merge 
-  tasks       =. |: ,: (<'task_id') ,: tasks
+  tasks       =. |: ,: (<'task_id') ,: ":each tasks
   
 
   output=. (report;.1~ [: -. ('|'={.)@>) result                                        NB. report per test

--- a/bin/run.ijs
+++ b/bin/run.ijs
@@ -3,7 +3,7 @@
 require'convert/json general/unittest'
 
 NB. todo: explore using 9!:24'' NB. security level. prevent student solutions from running certain i/o ops.
-
+NB. Simplify the process of substitution of test_name by description
 
 NB. ===================================================================================================================
 
@@ -12,7 +12,7 @@ NB. Those verbs are used only for the failure case
   get_message   =: 1 }. 1&{::
   get_test_name =: [: >@{.@;: 0&{:: 
 
-success =: (;:'status name message') ,: 'pass' ; ({. , {:)@:;:@:,@:>                   NB. Message will allways be 'OK'
+success=: (;:'status name message') ,: 'pass' ; ({. , {:)@:;:@:,@:>                   NB. Message will allways be 'OK'
 failure=: (;:'status name message test_code') ,: 'fail' ; get_test_name ; get_message ; get_test_code
 
 NB. ===================================================================================================================
@@ -75,12 +75,13 @@ main=: monad define
   descriptions=. dec_json 1!:1 descrPath                                               NB. the decription file will allways be created; it's absence is an error
   order       =. (dec_json@(1!:1) :: '') orderPath                                     NB. if order file does not exists the test were executed as defined
   tasks       =. (dec_json@(1!:1) :: (<"0 '1' #~ # descriptions)) tasksPath            NB. if tasks file does not exists test_code is '1' for all tests
+  
   (1!:55 :: '') descrPath                                                              NB. deletes helper file
   (1!:55 :: '') orderPath
   (1!:55 :: '') tasksPath
   
   descriptions=. |: ,: (<'name') ,: descriptions                                       NB. descriptions and tasks has shape (# tests) 2 1 in order to simplify the merge 
-  tasks=. |: ,: (<'task_id') ,: tasks
+  tasks       =. |: ,: (<'task_id') ,: tasks
   
 
   output=. (report;.1~ [: -. ('|'={.)@>) result                                        NB. report per test

--- a/tests/all-fail/example.ijs
+++ b/tests/all-fail/example.ijs
@@ -1,1 +1,1 @@
-nuc_cnt=: [: +/ =/&'ACGT'
+nucleotide_counts=: [: +/`(3 : '13!:8 (45)')@.(0 0 0 0&e.) =/&'ACGT'

--- a/tests/all-fail/expected_results.json
+++ b/tests/all-fail/expected_results.json
@@ -4,30 +4,37 @@
   "tests": [
     {
       "status": "fail",
-      "name": "nuc_cnt1",
-      "message": "|assertion failure: assert",
-      "test_code": "assert 0 0 0 0-:nuc_cnt''",
+      "name": "empty strand",
+      "message": "assertion failure: assert",
+      "test_code": "assert 0 0 0 0-:nucleotide_counts''",
       "task_id": "1"
     },
     {
       "status": "fail",
-      "name": "nuc_cnt2",
-      "message": "|assertion failure: assert",
-      "test_code": "assert 0 0 1 0-:nuc_cnt 1$'G'",
+      "name": "can count one nucleotide in single-character input",
+      "message": "assertion failure: assert",
+      "test_code": "assert 0 0 1 0-:nucleotide_counts 1$'G'",
       "task_id": "1"
     },
     {
       "status": "fail",
-      "name": "nuc_cnt3",
-      "message": "|assertion failure: assert",
-      "test_code": "assert 0 0 7 0-:nuc_cnt'GGGGGGG'",
+      "name": "strand with repeated nucleotide",
+      "message": "assertion failure: assert",
+      "test_code": "assert 0 0 7 0-:nucleotide_counts'GGGGGGG'",
       "task_id": "1"
     },
     {
       "status": "fail",
-      "name": "nuc_cnt4",
-      "message": "|assertion failure: assert",
-      "test_code": "assert 20 12 17 21-:nuc_cnt'AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC'",
+      "name": "strand with multiple nucleotides",
+      "message": "assertion failure: assert",
+      "test_code": "assert 20 12 17 21-:nucleotide_counts'AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC'",
+      "task_id": "1"
+    },
+    {
+      "status": "fail",
+      "name": "strand with invalid nucleotides",
+      "message": "assertion failure: assert",
+      "test_code": "assert(>@{:9!:8'')-:nucleotide_counts'AGXXACT'",
       "task_id": "1"
     }
   ]

--- a/tests/all-fail/nucleotide-count.ijs
+++ b/tests/all-fail/nucleotide-count.ijs
@@ -1,1 +1,1 @@
-nuc_cnt=: ]
+nucleotide_counts=: ]

--- a/tests/all-fail/test.ijs
+++ b/tests/all-fail/test.ijs
@@ -1,42 +1,54 @@
 load 'nucleotide-count.ijs'
 
 
-temppath=: < jpath '~temp/helper.txt'
-
-
-before_all =: monad define  
-  order=: i.0
-  tasks=: i.0
+before_all=: monad define  
+  (]Description =: (3 : 'descriptions=: i.0')`(3 : 'descriptions=: descriptions , < y'))@.0 ''
+  (]Order       =: (3 : 'order=: i.0')`(3 : 'order=: order , < y'))@.0 ''
+  (]Task        =: (3 : 'tasks=: i.0')`(3 : 'tasks=: tasks , < y'))@.0 '' 
 )
 
-after_all =: monad define
-  (, LF ,~"1 ":order ,. tasks) 1!:2 temppath
+
+nucleotid_counts_test_01_ignore=: 0
+test_nucleotid_counts_test_01  =: monad define
+  Description@.1 ('empty strand')
+  Order@.1 (1)
+  
+  NB. Expected=: 0 0 0 0
+  assert 0 0 0 0 -: nucleotide_counts ''
 )
 
-nuc_cnt1_ignore=:0
-test_nuc_cnt1=: monad define
-  order=:order , 1
-  tasks=:tasks , 1
-  assert 0 0 0 0-:nuc_cnt''
+nucleotid_counts_test_02_ignore=: 1 NB. Change this value to 0 to run this test
+test_nucleotid_counts_test_02  =: monad define
+  Description@.1 ('can count one nucleotide in single-character input')
+  Order@.1 (2)
+  
+  NB. Expected=: 0 0 1 0
+  assert 0 0 1 0 -: nucleotide_counts 1$'G'
 )
 
-nuc_cnt2_ignore=:0
-test_nuc_cnt2=: monad define
-  order=:order , 2
-  tasks=:tasks , 1
-  assert 0 0 1 0-:nuc_cnt 1$'G'
+nucleotid_counts_test_03_ignore=: 1 NB. Change this value to 0 to run this test
+test_nucleotid_counts_test_03  =: monad define
+  Description@.1 ('strand with repeated nucleotide')
+  Order@.1 (3)
+  
+  NB. Expected=: 0 0 7 0
+  assert 0 0 7 0 -: nucleotide_counts 'GGGGGGG'
 )
 
-nuc_cnt3_ignore=:0
-test_nuc_cnt3=: monad define
-  order=:order , 3
-  tasks=:tasks , 1
-  assert 0 0 7 0-:nuc_cnt'GGGGGGG'
+nucleotid_counts_test_04_ignore=: 1 NB. Change this value to 0 to run this test
+test_nucleotid_counts_test_04  =: monad define
+  Description@.1 ('strand with multiple nucleotides')
+  Order@.1 (4)
+  
+  NB. Expected=: 20 12 17 21
+  assert 20 12 17 21 -: nucleotide_counts 'AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC'
 )
 
-nuc_cnt4_ignore=:0
-test_nuc_cnt4=: monad define
-  order=:order , 4
-  tasks=:tasks , 1
-  assert 20 12 17 21-:nuc_cnt'AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC'
+nucleotid_counts_test_05_ignore=: 1 NB. Change this value to 0 to run this test
+test_nucleotid_counts_test_05  =: monad define
+  Description@.1 ('strand with invalid nucleotides')
+  Order@.1 (5)
+  
+  NB. Expected=: 'domain error'
+  assert (>@{: 9!:8 '') -: nucleotide_counts 'AGXXACT'
 )

--- a/tests/empty-file/example.ijs
+++ b/tests/empty-file/example.ijs
@@ -1,1 +1,1 @@
-nuc_cnt=: [: +/ =/&'ACGT'
+nucleotide_counts=: [: +/`(3 : '13!:8 (45)')@.(0 0 0 0&e.) =/&'ACGT'

--- a/tests/empty-file/expected_results.json
+++ b/tests/empty-file/expected_results.json
@@ -4,30 +4,37 @@
   "tests": [
     {
       "status": "fail",
-      "name": "nuc_cnt1",
-      "message": "|value error: nuc_cnt",
-      "test_code": "rt 0 0 0 0-:    nuc_cnt''",
+      "name": "empty strand",
+      "message": "value error: nucleotide_counts",
+      "test_code": "assert 0 0 0 0-:    nucleotide_counts''",
       "task_id": "1"
     },
     {
       "status": "fail",
-      "name": "nuc_cnt2",
-      "message": "|value error: nuc_cnt",
-      "test_code": "rt 0 0 1 0-:    nuc_cnt 1$'G'",
+      "name": "can count one nucleotide in single-character input",
+      "message": "value error: nucleotide_counts",
+      "test_code": "assert 0 0 1 0-:    nucleotide_counts 1$'G'",
       "task_id": "1"
     },
     {
       "status": "fail",
-      "name": "nuc_cnt3",
-      "message": "|value error: nuc_cnt",
-      "test_code": "rt 0 0 7 0-:    nuc_cnt'GGGGGGG'",
+      "name": "strand with repeated nucleotide",
+      "message": "value error: nucleotide_counts",
+      "test_code": "assert 0 0 7 0-:    nucleotide_counts'GGGGGGG'",
       "task_id": "1"
     },
     {
       "status": "fail",
-      "name": "nuc_cnt4",
-      "message": "|value error: nuc_cnt",
-      "test_code": "rt 20 12 17 21-:    nuc_cnt'AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC'",
+      "name": "strand with multiple nucleotides",
+      "message": "value error: nucleotide_counts",
+      "test_code": "assert 20 12 17 21-:    nucleotide_counts'AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC'",
+      "task_id": "1"
+    },
+    {
+      "status": "fail",
+      "name": "strand with invalid nucleotides",
+      "message": "value error: nucleotide_counts",
+      "test_code": "assert(>@{:9!:8'')-:    nucleotide_counts'AGXXACT'",
       "task_id": "1"
     }
   ]

--- a/tests/empty-file/test.ijs
+++ b/tests/empty-file/test.ijs
@@ -1,42 +1,54 @@
 load 'nucleotide-count.ijs'
 
 
-temppath=: < jpath '~temp/helper.txt'
-
-
-before_all =: monad define  
-  order=: i.0
-  tasks=: i.0
+before_all=: monad define  
+  (]Description =: (3 : 'descriptions=: i.0')`(3 : 'descriptions=: descriptions , < y'))@.0 ''
+  (]Order       =: (3 : 'order=: i.0')`(3 : 'order=: order , < y'))@.0 ''
+  (]Task        =: (3 : 'tasks=: i.0')`(3 : 'tasks=: tasks , < y'))@.0 '' 
 )
 
-after_all =: monad define
-  (, LF ,~"1 ":order ,. tasks) 1!:2 temppath
+
+nucleotid_counts_test_01_ignore=: 0
+test_nucleotid_counts_test_01  =: monad define
+  Description@.1 ('empty strand')
+  Order@.1 (1)
+  
+  NB. Expected=: 0 0 0 0
+  assert 0 0 0 0 -: nucleotide_counts ''
 )
 
-nuc_cnt1_ignore=:0
-test_nuc_cnt1=: monad define
-  order=:order , 1
-  tasks=:tasks , 1
-  assert 0 0 0 0-:nuc_cnt''
+nucleotid_counts_test_02_ignore=: 0 NB. Change this value to 0 to run this test
+test_nucleotid_counts_test_02  =: monad define
+  Description@.1 ('can count one nucleotide in single-character input')
+  Order@.1 (2)
+  
+  NB. Expected=: 0 0 1 0
+  assert 0 0 1 0 -: nucleotide_counts 1$'G'
 )
 
-nuc_cnt2_ignore=:0
-test_nuc_cnt2=: monad define
-  order=:order , 2
-  tasks=:tasks , 1
-  assert 0 0 1 0-:nuc_cnt 1$'G'
+nucleotid_counts_test_03_ignore=: 0 NB. Change this value to 0 to run this test
+test_nucleotid_counts_test_03  =: monad define
+  Description@.1 ('strand with repeated nucleotide')
+  Order@.1 (3)
+  
+  NB. Expected=: 0 0 7 0
+  assert 0 0 7 0 -: nucleotide_counts 'GGGGGGG'
 )
 
-nuc_cnt3_ignore=:0
-test_nuc_cnt3=: monad define
-  order=:order , 3
-  tasks=:tasks , 1
-  assert 0 0 7 0-:nuc_cnt'GGGGGGG'
+nucleotid_counts_test_04_ignore=: 0 NB. Change this value to 0 to run this test
+test_nucleotid_counts_test_04  =: monad define
+  Description@.1 ('strand with multiple nucleotides')
+  Order@.1 (4)
+  
+  NB. Expected=: 20 12 17 21
+  assert 20 12 17 21 -: nucleotide_counts 'AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC'
 )
 
-nuc_cnt4_ignore=:0
-test_nuc_cnt4=: monad define
-  order=:order , 4
-  tasks=:tasks , 1
-  assert 20 12 17 21-:nuc_cnt'AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC'
+nucleotid_counts_test_05_ignore=: 1 NB. Change this value to 0 to run this test
+test_nucleotid_counts_test_05  =: monad define
+  Description@.1 ('strand with invalid nucleotides')
+  Order@.1 (5)
+  
+  NB. Expected=: 'domain error'
+  assert (>@{: 9!:8 '') -: nucleotide_counts 'AGXXACT'
 )

--- a/tests/multiple-tasks/expected_results.json
+++ b/tests/multiple-tasks/expected_results.json
@@ -4,51 +4,57 @@
   "tests": [
     {
       "status": "pass",
-      "name": "square_of_sum_1",
+      "name": "square of sum 1",
       "message": "OK",
-      "task_id": "1"
+      "task_id": 1
     },
     {
       "status": "pass",
-      "name": "square_of_sum_5",
+      "name": "square of sum 5",
       "message": "OK",
-      "task_id": "1"
+      "task_id": 1
     },
     {
       "status": "pass",
-      "name": "square_of_sum_100",
+      "name": "square of sum 100",
       "message": "OK",
-      "task_id": "1"
+      "task_id": 1
     },
     {
       "status": "pass",
-      "name": "sum_of_square_5",
+      "name": "sum of squares 1",
       "message": "OK",
-      "task_id": "2"
+      "task_id": 2
     },
     {
       "status": "pass",
-      "name": "sum_of_square_100",
+      "name": "sum of squares 5",
       "message": "OK",
-      "task_id": "2"
+      "task_id": 2
     },
     {
       "status": "pass",
-      "name": "difference_of_squares_0",
+      "name": "sum of squares 100",
       "message": "OK",
-      "task_id": "3"
+      "task_id": 2
     },
     {
       "status": "pass",
-      "name": "difference_of_squares_5",
+      "name": "difference of squares 1",
       "message": "OK",
-      "task_id": "3"
+      "task_id": 3
     },
     {
       "status": "pass",
-      "name": "difference_of_squares_100",
+      "name": "difference of squares 5",
       "message": "OK",
-      "task_id": "3"
+      "task_id": 3
+    },
+    {
+      "status": "pass",
+      "name": "difference of squares 100",
+      "message": "OK",
+      "task_id": 3
     }
   ]
 }

--- a/tests/multiple-tasks/expected_results.json
+++ b/tests/multiple-tasks/expected_results.json
@@ -6,55 +6,55 @@
       "status": "pass",
       "name": "square of sum 1",
       "message": "OK",
-      "task_id": 1
+      "task_id": "1"
     },
     {
       "status": "pass",
       "name": "square of sum 5",
       "message": "OK",
-      "task_id": 1
+      "task_id": "1"
     },
     {
       "status": "pass",
       "name": "square of sum 100",
       "message": "OK",
-      "task_id": 1
+      "task_id": "1"
     },
     {
       "status": "pass",
       "name": "sum of squares 1",
       "message": "OK",
-      "task_id": 2
+      "task_id": "2"
     },
     {
       "status": "pass",
       "name": "sum of squares 5",
       "message": "OK",
-      "task_id": 2
+      "task_id": "2"
     },
     {
       "status": "pass",
       "name": "sum of squares 100",
       "message": "OK",
-      "task_id": 2
+      "task_id": "2"
     },
     {
       "status": "pass",
       "name": "difference of squares 1",
       "message": "OK",
-      "task_id": 3
+      "task_id": "3"
     },
     {
       "status": "pass",
       "name": "difference of squares 5",
       "message": "OK",
-      "task_id": 3
+      "task_id": "3"
     },
     {
       "status": "pass",
       "name": "difference of squares 100",
       "message": "OK",
-      "task_id": 3
+      "task_id": "3"
     }
   ]
 }

--- a/tests/multiple-tasks/test.ijs
+++ b/tests/multiple-tasks/test.ijs
@@ -1,61 +1,98 @@
 load 'difference-of-squares.ijs'
 
 
-temppath=: < jpath '~temp/helper.txt'
-
-before_all =: monad define  
-  order=: i.0
-  tasks=: i.0
+before_all=: monad define  
+  (]Description =: (3 : 'descriptions=: i.0')`(3 : 'descriptions=: descriptions , < y'))@.0 ''
+  (]Order       =: (3 : 'order=: i.0')`(3 : 'order=: order , < y'))@.0 ''
+  (]Task        =: (3 : 'tasks=: i.0')`(3 : 'tasks=: tasks , < y'))@.0 '' 
 )
 
-after_all =: monad define
-  (, LF ,~"1 ":order ,. tasks) 1!:2 temppath
-)
-
-test_square_of_sum_1 =: monad define
-  order=:order , 1
-  tasks=:tasks , 1
+square_of_sum_test_01_ignore=: 0
+test_square_of_sum_test_01  =: monad define
+  Description@.1 ('square of sum 1')
+  Order@.1 (1)
+  Task@.1 (1)
+  
+  NB. Expected=: 1
   assert 1 = square_of_sum 1
 )
 
-test_square_of_sum_5 =: monad define
-  order=:order , 2
-  tasks=:tasks , 1
+square_of_sum_test_02_ignore=: 1 NB. Change this value to 0 to run this test
+test_square_of_sum_test_02  =: monad define
+  Description@.1 ('square of sum 5')
+  Order@.1 (2)
+  Task@.1 (1)
+  
+  NB. Expected=: 225
   assert 225 = square_of_sum 5
 )
 
-test_square_of_sum_100 =: monad define
-  order=:order , 3
-  tasks=:tasks , 1
+square_of_sum_test_03_ignore=: 1 NB. Change this value to 0 to run this test
+test_square_of_sum_test_03  =: monad define
+  Description@.1 ('square of sum 100')
+  Order@.1 (3)
+  Task@.1 (1)
+  
+  NB. Expected=: 25502500
   assert 25502500 = square_of_sum 100
 )
 
-test_sum_of_square_5 =: monad define
-  order=:order , 4
-  tasks=:tasks , 2
+sum_of_square_test_01_ignore=: 1 NB. Change this value to 0 to run this test
+test_sum_of_square_test_01  =: monad define
+  Description@.1 ('sum of squares 1')
+  Order@.1 (4)
+  Task@.1 (2)
+  
+  NB. Expected=: 1
+  assert 1 = sum_of_square 1
+)
+
+sum_of_square_test_02_ignore=: 1 NB. Change this value to 0 to run this test
+test_sum_of_square_test_02  =: monad define
+  Description@.1 ('sum of squares 5')
+  Order@.1 (5)
+  Task@.1 (2)
+  
+  NB. Expected=: 55
   assert 55 = sum_of_square 5
 )
 
-test_sum_of_square_100 =: monad define
-  order=:order , 5
-  tasks=:tasks , 2
+sum_of_square_test_03_ignore=: 1 NB. Change this value to 0 to run this test
+test_sum_of_square_test_03  =: monad define
+  Description@.1 ('sum of squares 100')
+  Order@.1 (6)
+  Task@.1 (2)
+  
+  NB. Expected=: 338350
   assert 338350 = sum_of_square 100
 )
 
-test_difference_of_squares_0 =: monad define
-  order=:order , 6
-  tasks=:tasks , 3
-  assert 0 = difference_of_squares 0
+difference_of_squares_test_01_ignore=: 1 NB. Change this value to 0 to run this test
+test_difference_of_squares_test_01  =: monad define
+  Description@.1 ('difference of squares 1')
+  Order@.1 (7)
+  Task@.1 (3)
+  
+  NB. Expected=: 0
+  assert 0 = difference_of_squares 1
 )
 
-test_difference_of_squares_5 =: monad define
-  order=:order , 7
-  tasks=:tasks , 3
+difference_of_squares_test_02_ignore=: 1 NB. Change this value to 0 to run this test
+test_difference_of_squares_test_02  =: monad define
+  Description@.1 ('difference of squares 5')
+  Order@.1 (8)
+  Task@.1 (3)
+  
+  NB. Expected=: 170
   assert 170 = difference_of_squares 5
 )
 
-test_difference_of_squares_100 =: monad define
-  order=:order , 8
-  tasks=:tasks , 3
+difference_of_squares_test_03_ignore=: 1 NB. Change this value to 0 to run this test
+test_difference_of_squares_test_03  =: monad define
+  Description@.1 ('difference of squares 100')
+  Order@.1 (9)
+  Task@.1 (3)
+  
+  NB. Expected=: 25164150
   assert 25164150 = difference_of_squares 100
 )

--- a/tests/partial-fail/example.ijs
+++ b/tests/partial-fail/example.ijs
@@ -1,1 +1,1 @@
-nuc_cnt=: [: +/ =/&'ACGT'
+nucleotide_counts=: [: +/`(3 : '13!:8 (45)')@.(0 0 0 0&e.) =/&'ACGT'

--- a/tests/partial-fail/expected_results.json
+++ b/tests/partial-fail/expected_results.json
@@ -3,28 +3,35 @@
   "status": "fail",
   "tests": [
     {
+      "status": "fail",
+      "name": "empty strand",
+      "message": "assertion failure: assert",
+      "test_code": "assert 0 0 0 0 0-:nucleotide_counts''",
+      "task_id": "1"
+    },
+    {
       "status": "pass",
-      "name": "nuc_cnt1",
+      "name": "can count one nucleotide in single-character input",
+      "message": "OK",
+      "task_id": "1"
+    },
+    {
+      "status": "pass",
+      "name": "strand with repeated nucleotide",
+      "message": "OK",
+      "task_id": "1"
+    },
+    {
+      "status": "pass",
+      "name": "strand with multiple nucleotides",
       "message": "OK",
       "task_id": "1"
     },
     {
       "status": "fail",
-      "name": "nuc_cnt2",
-      "message": "|assertion failure: assert",
-      "test_code": "assert 0 0 1 0-:1,nuc_cnt 1$'G'",
-      "task_id": "1"
-    },
-    {
-      "status": "pass",
-      "name": "nuc_cnt3",
-      "message": "OK",
-      "task_id": "1"
-    },
-    {
-      "status": "pass",
-      "name": "nuc_cnt4",
-      "message": "OK",
+      "name": "strand with invalid nucleotides",
+      "message": "value error: nucleotide_counts",
+      "test_code": "13!:8(21)",
       "task_id": "1"
     }
   ]

--- a/tests/partial-fail/nucleotide-count.ijs
+++ b/tests/partial-fail/nucleotide-count.ijs
@@ -1,1 +1,1 @@
-nuc_cnt=: [: +/ =/&'ACGT'
+nucleotide_counts=: [: +/`(3 : '13!:8 (21)')@.(0 0 0 0&e.) =/&'ACGT'

--- a/tests/partial-fail/test.ijs
+++ b/tests/partial-fail/test.ijs
@@ -1,42 +1,55 @@
 load 'nucleotide-count.ijs'
 
 
-temppath=: < jpath '~temp/helper.txt'
-
-
-before_all =: monad define  
-  order=: i.0
-  tasks=: i.0
+before_all=: monad define  
+  (]Description =: (3 : 'descriptions=: i.0')`(3 : 'descriptions=: descriptions , < y'))@.0 ''
+  (]Order       =: (3 : 'order=: i.0')`(3 : 'order=: order , < y'))@.0 ''
+  (]Task        =: (3 : 'tasks=: i.0')`(3 : 'tasks=: tasks , < y'))@.0 '' 
 )
 
-after_all =: monad define
-  (, LF ,~"1 ":order ,. tasks) 1!:2 temppath
+
+nucleotid_counts_test_01_ignore=: 0
+test_nucleotid_counts_test_01  =: monad define
+  Description@.1 ('empty strand')
+  Order@.1 (1)
+  
+  NB. Expected=: 0 0 0 0
+  assert 0 0 0 0 0 -: nucleotide_counts '' NB. This test will fail
 )
 
-nuc_cnt1_ignore=:0
-test_nuc_cnt1=: monad define
-  order=:order , 1
-  tasks=:tasks , 1
-  assert 0 0 0 0-:nuc_cnt''
+nucleotid_counts_test_02_ignore=: 1 NB. Change this value to 0 to run this test
+test_nucleotid_counts_test_02  =: monad define
+  Description@.1 ('can count one nucleotide in single-character input')
+  Order@.1 (2)
+  
+  NB. Expected=: 0 0 1 0
+  assert 0 0 1 0 -: nucleotide_counts 1$'G'
 )
 
-nuc_cnt2_ignore=:0
-test_nuc_cnt2=: monad define
-  order=:order , 2
-  tasks=:tasks , 1
-  assert 0 0 1 0-: 1 , nuc_cnt 1$'G' NB. This test should fail
+nucleotid_counts_test_03_ignore=: 1 NB. Change this value to 0 to run this test
+test_nucleotid_counts_test_03  =: monad define
+  Description@.1 ('strand with repeated nucleotide')
+  Order@.1 (3)
+  
+  NB. Expected=: 0 0 7 0
+  assert 0 0 7 0 -: nucleotide_counts 'GGGGGGG'
 )
 
-nuc_cnt3_ignore=:0
-test_nuc_cnt3=: monad define
-  order=:order , 3
-  tasks=:tasks , 1
-  assert 0 0 7 0-:nuc_cnt'GGGGGGG'
+nucleotid_counts_test_04_ignore=: 1 NB. Change this value to 0 to run this test
+test_nucleotid_counts_test_04  =: monad define
+  Description@.1 ('strand with multiple nucleotides')
+  Order@.1 (4)
+  
+  NB. Expected=: 20 12 17 21
+  assert 20 12 17 21 -: nucleotide_counts 'AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC'
 )
 
-nuc_cnt4_ignore=:0
-test_nuc_cnt4=: monad define
-  order=:order , 4
-  tasks=:tasks , 1
-  assert 20 12 17 21-:nuc_cnt'AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC'
+nucleotid_counts_test_05_ignore=: 1 NB. Change this value to 0 to run this test
+nucleotid_counts_test_05_expect=: 'domain error'
+test_nucleotid_counts_test_05  =: monad define
+  Description@.1 ('strand with invalid nucleotides')
+  Order@.1 (5)
+  
+  NB. Expected=: 'domain error'
+  assert (>@{: 9!:8 '') -: nucleotide_counts 'AGXXACT' NB. This test will fail
 )

--- a/tests/success/example.ijs
+++ b/tests/success/example.ijs
@@ -1,1 +1,1 @@
-nuc_cnt=: [: +/ =/&'ACGT'
+nucleotide_counts=: [: +/`(3 : '13!:8 (45)')@.(0 0 0 0&e.) =/&'ACGT'

--- a/tests/success/expected_results.json
+++ b/tests/success/expected_results.json
@@ -4,25 +4,31 @@
   "tests": [
     {
       "status": "pass",
-      "name": "nuc_cnt1",
+      "name": "empty strand",
       "message": "OK",
       "task_id": "1"
     },
     {
       "status": "pass",
-      "name": "nuc_cnt2",
+      "name": "can count one nucleotide in single-character input",
       "message": "OK",
       "task_id": "1"
     },
     {
       "status": "pass",
-      "name": "nuc_cnt3",
+      "name": "strand with repeated nucleotide",
       "message": "OK",
       "task_id": "1"
     },
     {
       "status": "pass",
-      "name": "nuc_cnt4",
+      "name": "strand with multiple nucleotides",
+      "message": "OK",
+      "task_id": "1"
+    },
+    {
+      "status": "pass",
+      "name": "strand with invalid nucleotides",
       "message": "OK",
       "task_id": "1"
     }

--- a/tests/success/nucleotide-count.ijs
+++ b/tests/success/nucleotide-count.ijs
@@ -1,1 +1,1 @@
-nuc_cnt=: [: +/ =/&'ACGT'
+nucleotide_counts=: [: +/`(3 : '13!:8 (45)')@.(0 0 0 0&e.) =/&'ACGT'

--- a/tests/success/test.ijs
+++ b/tests/success/test.ijs
@@ -1,42 +1,55 @@
 load 'nucleotide-count.ijs'
 
 
-temppath=: < jpath '~temp/helper.txt'
-
-
-before_all =: monad define  
-  order=: i.0
-  tasks=: i.0
+before_all=: monad define  
+  (]Description =: (3 : 'descriptions=: i.0')`(3 : 'descriptions=: descriptions , < y'))@.0 ''
+  (]Order       =: (3 : 'order=: i.0')`(3 : 'order=: order , < y'))@.0 ''
+  (]Task        =: (3 : 'tasks=: i.0')`(3 : 'tasks=: tasks , < y'))@.0 '' 
 )
 
-after_all =: monad define
-  (, LF ,~"1 ":order ,. tasks) 1!:2 temppath
+
+nucleotid_counts_test_01_ignore=: 0
+test_nucleotid_counts_test_01  =: monad define
+  Description@.1 ('empty strand')
+  Order@.1 (1)
+  
+  NB. Expected=: 0 0 0 0
+  assert 0 0 0 0 -: nucleotide_counts ''
 )
 
-nuc_cnt1_ignore=:0
-test_nuc_cnt1=: monad define
-  order=:order , 1
-  tasks=:tasks , 1
-  assert 0 0 0 0-:nuc_cnt''
+nucleotid_counts_test_02_ignore=: 1 NB. Change this value to 0 to run this test
+test_nucleotid_counts_test_02  =: monad define
+  Description@.1 ('can count one nucleotide in single-character input')
+  Order@.1 (2)
+  
+  NB. Expected=: 0 0 1 0
+  assert 0 0 1 0 -: nucleotide_counts 1$'G'
 )
 
-nuc_cnt2_ignore=:0
-test_nuc_cnt2=: monad define
-  order=:order , 2
-  tasks=:tasks , 1
-  assert 0 0 1 0-:nuc_cnt 1$'G'
+nucleotid_counts_test_03_ignore=: 1 NB. Change this value to 0 to run this test
+test_nucleotid_counts_test_03  =: monad define
+  Description@.1 ('strand with repeated nucleotide')
+  Order@.1 (3)
+  
+  NB. Expected=: 0 0 7 0
+  assert 0 0 7 0 -: nucleotide_counts 'GGGGGGG'
 )
 
-nuc_cnt3_ignore=:0
-test_nuc_cnt3=: monad define
-  order=:order , 3
-  tasks=:tasks , 1
-  assert 0 0 7 0-:nuc_cnt'GGGGGGG'
+nucleotid_counts_test_04_ignore=: 1 NB. Change this value to 0 to run this test
+test_nucleotid_counts_test_04  =: monad define
+  Description@.1 ('strand with multiple nucleotides')
+  Order@.1 (4)
+  
+  NB. Expected=: 20 12 17 21
+  assert 20 12 17 21 -: nucleotide_counts 'AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC'
 )
 
-nuc_cnt4_ignore=:0
-test_nuc_cnt4=: monad define
-  order=:order , 4
-  tasks=:tasks , 1
-  assert 20 12 17 21-:nuc_cnt'AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC'
+nucleotid_counts_test_05_ignore=: 1 NB. Change this value to 0 to run this test
+nucleotid_counts_test_05_expect=: 'domain error'
+test_nucleotid_counts_test_05  =: monad define
+  Description@.1 ('strand with invalid nucleotides')
+  Order@.1 (5)
+  
+  NB. Expected=: 'domain error'
+  assert (>@{: 9!:8 '') -: nucleotide_counts 'AGXXACT'
 )

--- a/tests/syntax-error/example.ijs
+++ b/tests/syntax-error/example.ijs
@@ -1,1 +1,1 @@
-nuc_cnt=: [: +/ =/&'ACGT'
+nucleotide_counts=: [: +/`(3 : '13!:8 (45)')@.(0 0 0 0&e.) =/&'ACGT'

--- a/tests/syntax-error/expected_results.json
+++ b/tests/syntax-error/expected_results.json
@@ -1,5 +1,5 @@
 {
   "version": 3,
   "status": "error",
-  "message": "|syntax error in script, unexecutable fragment (noun verb)\n|   nuc_cnt=:    ''<\n|[-1] nucleotide-count.ijs\n"
+  "message": "|syntax error in script, unexecutable fragment (noun verb)\n|   nucleotide_counts=:    ''<\n|[-1] nucleotide-count.ijs\n"
 }

--- a/tests/syntax-error/nucleotide-count.ijs
+++ b/tests/syntax-error/nucleotide-count.ijs
@@ -1,1 +1,1 @@
-nuc_cnt=: '' < NB. 'syntax error
+nucleotide_counts=: '' < NB. 'syntax error

--- a/tests/syntax-error/test.ijs
+++ b/tests/syntax-error/test.ijs
@@ -1,42 +1,55 @@
 load 'nucleotide-count.ijs'
 
 
-temppath=: < jpath '~temp/helper.txt'
-
-
-before_all =: monad define  
-  order=: i.0
-  tasks=: i.0
+before_all=: monad define  
+  (]Description =: (3 : 'descriptions=: i.0')`(3 : 'descriptions=: descriptions , < y'))@.0 ''
+  (]Order       =: (3 : 'order=: i.0')`(3 : 'order=: order , < y'))@.0 ''
+  (]Task        =: (3 : 'tasks=: i.0')`(3 : 'tasks=: tasks , < y'))@.0 '' 
 )
 
-after_all =: monad define
-  (, LF ,~"1 ":order ,. tasks) 1!:2 temppath
+
+nucleotid_counts_test_01_ignore=: 0
+test_nucleotid_counts_test_01  =: monad define
+  Description@.1 ('empty strand')
+  Order@.1 (1)
+  
+  NB. Expected=: 0 0 0 0
+  assert 0 0 0 0 -: nucleotide_counts ''
 )
 
-nuc_cnt1_ignore=:0
-test_nuc_cnt1=: monad define
-  order=:order , 1
-  tasks=:tasks , 1
-  assert 0 0 0 0-:nuc_cnt''
+nucleotid_counts_test_02_ignore=: 1 NB. Change this value to 0 to run this test
+test_nucleotid_counts_test_02  =: monad define
+  Description@.1 ('can count one nucleotide in single-character input')
+  Order@.1 (2)
+  
+  NB. Expected=: 0 0 1 0
+  assert 0 0 1 0 -: nucleotide_counts 1$'G'
 )
 
-nuc_cnt2_ignore=:0
-test_nuc_cnt2=: monad define
-  order=:order , 2
-  tasks=:tasks , 1
-  assert 0 0 1 0-:nuc_cnt 1$'G'
+nucleotid_counts_test_03_ignore=: 1 NB. Change this value to 0 to run this test
+test_nucleotid_counts_test_03  =: monad define
+  Description@.1 ('strand with repeated nucleotide')
+  Order@.1 (3)
+  
+  NB. Expected=: 0 0 7 0
+  assert 0 0 7 0 -: nucleotide_counts 'GGGGGGG'
 )
 
-nuc_cnt3_ignore=:0
-test_nuc_cnt3=: monad define
-  order=:order , 3
-  tasks=:tasks , 1
-  assert 0 0 7 0-:nuc_cnt'GGGGGGG'
+nucleotid_counts_test_04_ignore=: 1 NB. Change this value to 0 to run this test
+test_nucleotid_counts_test_04  =: monad define
+  Description@.1 ('strand with multiple nucleotides')
+  Order@.1 (4)
+  
+  NB. Expected=: 20 12 17 21
+  assert 20 12 17 21 -: nucleotide_counts 'AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC'
 )
 
-nuc_cnt4_ignore=:0
-test_nuc_cnt4=: monad define
-  order=:order , 4
-  tasks=:tasks , 1
-  assert 20 12 17 21-:nuc_cnt'AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC'
+nucleotid_counts_test_05_ignore=: 1 NB. Change this value to 0 to run this test
+nucleotid_counts_test_05_expect=: 'domain error'
+test_nucleotid_counts_test_05  =: monad define
+  Description@.1 ('strand with invalid nucleotides')
+  Order@.1 (5)
+  
+  NB. Expected=: 'domain error'
+  assert (>@{: 9!:8 '') -: nucleotide_counts 'AGXXACT'
 )

--- a/tests/unordered/expected_results.json
+++ b/tests/unordered/expected_results.json
@@ -4,37 +4,37 @@
   "tests": [
     {
       "status": "pass",
-      "name": "empty_rna_sequence",
+      "name": "Empty RNA sequence",
       "message": "OK",
       "task_id": "1"
     },
     {
       "status": "pass",
-      "name": "rna_complement_of_cytosine_is_guanine",
+      "name": "RNA complement of cytosine is guanine",
       "message": "OK",
       "task_id": "1"
     },
     {
       "status": "pass",
-      "name": "rna_complement_of_guanine_is_cytosine",
+      "name": "RNA complement of guanine is cytosine",
       "message": "OK",
       "task_id": "1"
     },
     {
       "status": "pass",
-      "name": "rna_complement_of_thymine_is_adenine",
+      "name": "RNA complement of thymine is adenine",
       "message": "OK",
       "task_id": "1"
     },
     {
       "status": "pass",
-      "name": "rna_complement_of_adenine_is_uracil",
+      "name": "RNA complement of adenine is uracil",
       "message": "OK",
       "task_id": "1"
     },
     {
       "status": "pass",
-      "name": "rna_complement",
+      "name": "RNA complement",
       "message": "OK",
       "task_id": "1"
     }

--- a/tests/unordered/rna-transcription.ijs
+++ b/tests/unordered/rna-transcription.ijs
@@ -1,1 +1,1 @@
-rna=: 'UGCA' {~ 'ACGT'&i.
+to_rna=: 'UGCA' {~ 'ACGT'&i.

--- a/tests/unordered/test.ijs
+++ b/tests/unordered/test.ijs
@@ -1,50 +1,63 @@
 load 'rna-transcription.ijs'
 
 
-temppath=: < jpath '~temp/helper.txt'
-
-
 before_all=: monad define  
-  order=: i.0
-  tasks=: i.0
+  (]Description =: (3 : 'descriptions=: i.0')`(3 : 'descriptions=: descriptions , < y'))@.0 ''
+  (]Order       =: (3 : 'order=: i.0')`(3 : 'order=: order , < y'))@.0 ''
+  (]Task        =: (3 : 'tasks=: i.0')`(3 : 'tasks=: tasks , < y'))@.0 '' 
 )
 
-after_all=: monad define
-  (, LF ,~"1 ":order ,. tasks) 1!:2 temppath
+
+rna_transcription_test_01_ignore=: 0
+test_rna_transcription_test_01  =: monad define
+  Description@.1 ('Empty RNA sequence')
+  Order@.1 (1)
+  
+  NB. Expected=: ''
+  assert '' -: to_rna ''
 )
 
-test_empty_rna_sequence=: monad define
-  order=:order , 1
-  tasks=: tasks, 1
-  assert ''-:rna''
+rna_transcription_test_02_ignore=: 1 NB. Change this value to 0 to run this test
+test_rna_transcription_test_02  =: monad define
+  Description@.1 ('RNA complement of cytosine is guanine')
+  Order@.1 (2)
+  
+  NB. Expected=: 'C'
+  assert 'C' -: to_rna 'G'
 )
 
-test_rna_complement_of_cytosine_is_guanine=: monad define
-  order=:order , 2
-  tasks=: tasks, 1
-  assert 'C'-:rna'G'
+rna_transcription_test_03_ignore=: 1 NB. Change this value to 0 to run this test
+test_rna_transcription_test_03  =: monad define
+  Description@.1 ('RNA complement of guanine is cytosine')
+  Order@.1 (3)
+  
+  NB. Expected=: 'G'
+  assert 'G' -: to_rna 'C'
 )
 
-test_rna_complement_of_guanine_is_cytosine=: monad define
-  order=:order , 3
-  tasks=: tasks, 1
-  assert 'G'-:rna'C'
+rna_transcription_test_04_ignore=: 1 NB. Change this value to 0 to run this test
+test_rna_transcription_test_04  =: monad define
+  Description@.1 ('RNA complement of thymine is adenine')
+  Order@.1 (4)
+  
+  NB. Expected=: 'A'
+  assert 'A' -: to_rna'T'
 )
 
-test_rna_complement_of_thymine_is_adenine=: monad define
-  order=:order , 4
-  tasks=: tasks, 1
-  assert 'A'-:rna'T'
+rna_transcription_test_05_ignore=: 1 NB. Change this value to 0 to run this test
+test_rna_transcription_test_05  =: monad define
+  Description@.1 ('RNA complement of adenine is uracil')
+  Order@.1 (5)
+  
+  NB. Expected=: 'U'
+  assert 'U' -: to_rna'A'
 )
 
-test_rna_complement_of_adenine_is_uracil=: monad define
-  order=:order , 5
-  tasks=: tasks, 1
-  assert 'U'-:rna'A'
-)
-
-test_rna_complement=: monad define
-  order=:order , 6
-  tasks=: tasks, 1
-  assert 'UGCACCAGAAUU'-:rna'ACGTGGTCTTAA'
+rna_transcription_test_06_ignore=: 1 NB. Change this value to 0 to run this test
+test_rna_transcription_test_06  =: monad define
+  Description@.1 ('RNA complement')
+  Order@.1 (6)
+  
+  NB. Expected=: 'UGCACCAGAAUU'
+  assert 'UGCACCAGAAUU' -: to_rna 'ACGTGGTCTTAA'
 )


### PR DESCRIPTION
In this pull request:
 * The label `name` in the generated JSON is synchronized with the `description` in canonical-data.json.
 * The use of helper files is simplified:
   * Order and task_id information will not be stored if it's not necessary.
   * All file handling is now done in the test runner (previously, files were created by the test.ijs file in the solution and deleted either by the test runner or by the JE).
 * The tests folder contents is updated to align with the above changes.
 * Reformatting comments.