### PR TITLE
Make the test runner work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,21 @@
+FROM debian:stable-slim AS build
+ARG VERSION=j9.5
+
+ADD https://www.jsoftware.com/download/${VERSION}/install/${VERSION}_linux64.tar.gz /opt/${VERSION}_linux64.tar.gz
+WORKDIR /opt
+RUN apt-get update && apt-get install --yes --no-install-recommends patchelf 
+RUN tar -xvf ${VERSION}_linux64.tar.gz && \
+    patchelf --clear-execstack /opt/${VERSION}/bin/libj.so && \
+    /opt/${VERSION}/bin/jconsole -js "load'pacman'" "'update'jpkg''" "'install'jpkg'convert/json'" "'install'jpkg'general/unittest'" "exit 0"
+
 FROM debian:stable-slim
+ARG VERSION=j9.5
 
-# install packages required to run the tests
-RUN apt-get update \
-      && apt-get install -y --no-install-recommends \
-            wget \
-            jq \
-            coreutils \
-            moreutils \
-            ca-certificates \
-      && apt-get clean \
-      && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install --yes --no-install-recommends jq && rm -r /var/lib/apt/lists/*
 
-RUN wget https://www.jsoftware.com/download/j9.5/install/j9.5_linux64.tar.gz \
-      && tar -xvf j9.5_linux64.tar.gz \
-      && mv j9.5 /opt/j9.5 \
-      && apt-get -y --purge remove wget ca-certificates \
-      && rm -rf j9.5_linux64.tar.gz
-
-RUN /opt/j9.5/bin/jconsole -js \
-      "load'pacman'" \
-      "'update'jpkg''" \
-      "'install'jpkg'convert/json'" \
-      "'install'jpkg'general/unittest'" \
-      "exit 0"
-
-RUN mkdir /opt/test-runner
 WORKDIR /opt/test-runner
+
+COPY --from=build /opt/${VERSION} /opt/${VERSION}
 COPY . .
+
 ENTRYPOINT ["/opt/test-runner/bin/run.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:stable-slim AS build
+FROM debian:trixie-slim@sha256:109e2c65005bf160609e4ba6acf7783752f8502ad218e298253428690b9eaa4b AS build
 ARG VERSION=j9.5
 
 ADD https://www.jsoftware.com/download/${VERSION}/install/${VERSION}_linux64.tar.gz /opt/${VERSION}_linux64.tar.gz
@@ -8,7 +8,7 @@ RUN tar -xvf ${VERSION}_linux64.tar.gz && \
     patchelf --clear-execstack /opt/${VERSION}/bin/libj.so && \
     /opt/${VERSION}/bin/jconsole -js "load'pacman'" "'update'jpkg''" "'install'jpkg'convert/json'" "'install'jpkg'general/unittest'" "exit 0"
 
-FROM debian:stable-slim
+FROM debian:trixie-slim@sha256:109e2c65005bf160609e4ba6acf7783752f8502ad218e298253428690b9eaa4b
 ARG VERSION=j9.5
 
 RUN apt-get update && apt-get install --yes --no-install-recommends jq && rm -r /var/lib/apt/lists/*

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -35,6 +35,7 @@ echo "${slug}: testing..."
 # stderr to capture it
 test_output=$(/opt/j9.5/bin/jconsole bin/run.ijs "$slug" "$solution_dir/" "$output_dir/")
 
-jq . ${results_file} | sponge ${results_file}
+result=$(jq . "${results_file}")
+printf '%s\n' "${result}" > "${results_file}"
 
 echo "${slug}: done"


### PR DESCRIPTION
* The shared library (`libj.so`) demands an executable stack, which modern Linux systems block for security (Data Execution Prevention). This is fixed by clearing the executable flag on the library using `patchelf --clear-execstack libj.so`.
* Use Dockerfile `ADD` to download the tar file.
* Split into a build and run layer; set up `/opt/j9.5` in build then copy it to the run layer
* Remove dependency on `sponge` in the runner.